### PR TITLE
fix: hashes now on the right files

### DIFF
--- a/scripts/hashes.py
+++ b/scripts/hashes.py
@@ -2,6 +2,7 @@ import json
 import os
 import hashlib
 
+
 def getFileHash(filename, alg, chunksize=131072):
     if (alg == 'sha256'):
         h = hashlib.sha256()
@@ -11,22 +12,52 @@ def getFileHash(filename, alg, chunksize=131072):
         h = hashlib.md5()
 
     with open(filename, 'rb', buffering=0) as f:
-        for b in iter(lambda : f.read(chunksize), b''):
+        for b in iter(lambda: f.read(chunksize), b''):
             h.update(b)
     return h.hexdigest()
 
+
+'''
+    check if rom is present in the list of files in json
+    return: -1 if no rom is listed, rom's filename if found
+'''
+
+
+def lookForRom(files):
+    for f in range(0, len(files)):
+        ext = files[f]['filename'].split('.')[-1]
+        if ext.lower() in ['gb', 'gbc', 'cgb', 'gba', 'agb']:
+            return files[f]['filename']
+
+    return -1
+
+
+# number of files without a rom
+c = 0
+
 for folder in os.listdir('../entries'):
+    s = ""
     with open('../entries/'+folder+'/game.json') as f:
         data = json.load(f)
-    print(data["slug"])
+
+    s += '{0: <30}'.format(data["slug"] + " ")
     gamePath = '../entries/'+folder+'/'
-    try:
-        print(getFileHash(gamePath+data['rom'], 'md5'))
-    except:
-        print('No ROM')
-    try:
-        for fileArray in data["files"]:
-            fileName = fileArray[0]
-            print(getFileHash(gamePath+fileName, 'md5'))
-    except:
-        print('No files')
+
+    rom_name = lookForRom(data['files'])
+
+    if(rom_name != -1):
+        try:
+            s += getFileHash(gamePath+rom_name, 'md5')
+            '''
+            s += '\t\t' + gamePath+rom_name + "\t\t" + \
+                getFileHash(gamePath+rom_name, 'md5')
+            '''
+        except:
+            s += '\t\tNo ROM detected'
+    else:
+        s += ("No ROM detected")
+        c += 1
+
+    print(s)
+
+print("# without a rom: " + str(c))

--- a/scripts/hashes.py
+++ b/scripts/hashes.py
@@ -26,7 +26,7 @@ def getFileHash(filename, alg, chunksize=131072):
 def lookForRom(files):
     for f in range(0, len(files)):
         ext = files[f]['filename'].split('.')[-1]
-        if ext.lower() in ['gb', 'gbc', 'cgb', 'gba', 'agb']:
+        if ext.lower() in ['gb', 'gbc', 'cgb', 'gba', 'agb', 'sgb']:
             return files[f]['filename']
 
     return -1


### PR DESCRIPTION
Before:
`getFileHash(gamePath+data['rom'], 'md5')`

This doesn't work, because:
- not every file has "rom" key
- "rom" key in json is not defined anywhere in schema, so I think it's an old leftover
- it tells "No ROM file", but that's not true; json are simply missing "rom" field (but it's normal since we've deprecated it)

After:
- we look for files in the files array in each hb-rom directory
- after we get the file with the rom, we calculate the checksum
- finally we print slug and chksum