### PR TITLE
add: dupe finder script

### DIFF
--- a/scripts/dupe_finder.py
+++ b/scripts/dupe_finder.py
@@ -26,7 +26,7 @@ def getFileHash(filename, alg, chunksize=131072):
 def lookForRom(files):
     for f in range(0, len(files)):
         ext = files[f]['filename'].split('.')[-1]
-        if ext.lower() in ['gb', 'gbc', 'cgb', 'gba', 'agb']:
+        if ext.lower() in ['gb', 'gbc', 'cgb', 'gba', 'agb', 'sgb']:
             return files[f]['filename']
 
     return -1

--- a/scripts/dupe_finder.py
+++ b/scripts/dupe_finder.py
@@ -31,8 +31,7 @@ def look_for_rom(files):
     return -1
 
 
-d = dict()      # a dictionary has been created since dictionaries are really useful to detect unique things.
-
+d = dict()
 for folder in os.listdir('../entries'):
     with open('../entries/'+folder+'/game.json') as f:
         data = json.load(f)

--- a/scripts/dupe_finder.py
+++ b/scripts/dupe_finder.py
@@ -1,0 +1,63 @@
+import json
+import os
+import hashlib
+
+
+def getFileHash(filename, alg, chunksize=131072):
+    if (alg == 'sha256'):
+        h = hashlib.sha256()
+    elif (alg == 'sha1'):
+        h = hashlib.sha1()
+    elif (alg == 'md5'):
+        h = hashlib.md5()
+
+    with open(filename, 'rb', buffering=0) as f:
+        for b in iter(lambda: f.read(chunksize), b''):
+            h.update(b)
+    return h.hexdigest()
+
+
+'''
+    check if rom is present in the list of files in json
+    return: -1 if no rom is listed, rom's filename if found
+'''
+
+
+def lookForRom(files):
+    for f in range(0, len(files)):
+        ext = files[f]['filename'].split('.')[-1]
+        if ext.lower() in ['gb', 'gbc', 'cgb', 'gba', 'agb']:
+            return files[f]['filename']
+
+    return -1
+
+
+# dictionary to keep track of entries
+# keys -> hash
+# values -> slugs
+# if a homebrew is duped, then it should have more than one slugs
+d = dict()
+
+for folder in os.listdir('../entries'):
+    with open('../entries/'+folder+'/game.json') as f:
+        data = json.load(f)
+
+    gamePath = '../entries/'+folder+'/'
+
+    rom_name = lookForRom(data['files'])
+
+    if(rom_name != -1):
+        try:
+            hash = getFileHash(gamePath+rom_name, 'md5')
+            if hash not in d:
+                d[hash] = []
+
+            d[hash].append(data["slug"])
+        except:
+            print(data["slug"] + ": hash can't be retrieved.")
+    else:
+        print(data["slug"] + ": hash can't be retrieved.")
+
+for key in d:
+    if len(d[key]) > 1:
+        print("Duped hb, slugs are: " + str(d[key]))


### PR DESCRIPTION
Related to: #35 

It is useful for a manual review, since we can't "just merge" every duped rom in a giant unique folder, but we need to take care of screenshots and information in Json files (because sometimes a duplicate contains more information than others).

This script prints which slugs are duped.

It could be useful in future before adding new entries.

The workflow could be this:
- assuming that no dupes are present in the database *really important*
  - run your importer, and place your roms manually, in the `entries` directory
  - run this script
 
Since there should be no dupes before placing the new roms, you should be able to see if your roms are already present in the entries folder. If it's the case, just add the missing information in the json already in the entries folder, and you're ready to make a PR!