### PR TITLE
Erroneous trailing comma

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ In the folder we just created, create a file called `game.json`. Here's a basic 
     "repository": "https://github.com/Sanqui/2048-gb",
     "screenshots": [
         "1.png",
+        "2.png"
     ],
     "slug": "2048gb",
     "tags": [


### PR DESCRIPTION
Added a second screenshot line to make it clear that there should be no final trailing comma in the description json.